### PR TITLE
fix : return working path to original state after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-start_dir=`pwd`
+pushd $(pwd)
 
 function fail() {
 	printf '%s\n' "$1" >&2 ## Send message to stderr.
@@ -15,14 +15,14 @@ read -rd '' globalhelp <<-EOF
 	usage
 	-----
 	./install.bash <options>
-	
+
 	options and explanations
 	---------------------------
 	  help : Print this help message
-	
+
 	  dpath : Path to download source of libraries (created if it does not exist).
 	          Defaults to ${HOME}/Desktop/third_party/
-	
+
 	  installpath : Path to install libraries (created if it does not exist).
 	          Defaults to ${HOME}/Desktop/third_party_installed/
 EOF
@@ -104,4 +104,4 @@ unset SCRIPT_DIR
 unset INSTALL_PATH
 unset DOWNLOAD_PATH
 
-cd $start_dir
+popd

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+start_dir=`pwd`
+
 function fail() {
 	printf '%s\n' "$1" >&2 ## Send message to stderr.
 	exit "${2-1}"          ## Return a code specified by $2, or 1 by default.
@@ -101,3 +103,5 @@ unset -f setup_library
 unset SCRIPT_DIR
 unset INSTALL_PATH
 unset DOWNLOAD_PATH
+
+cd $start_dir

--- a/install.sh
+++ b/install.sh
@@ -15,14 +15,14 @@ read -rd '' globalhelp <<-EOF
 	usage
 	-----
 	./install.bash <options>
-
+	
 	options and explanations
 	---------------------------
 	  help : Print this help message
-
+	
 	  dpath : Path to download source of libraries (created if it does not exist).
 	          Defaults to ${HOME}/Desktop/third_party/
-
+	
 	  installpath : Path to install libraries (created if it does not exist).
 	          Defaults to ${HOME}/Desktop/third_party_installed/
 EOF


### PR DESCRIPTION
Added `cd` to return to starting directory.