### PR TITLE
feat : support setting compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@ bash install.sh help # (or zsh install.sh help)
 which prints the following message
 > usage
 > -----
-> ./install.bash <options>
+> ./install.sh [-d dpath] [-i ipath] [-c compiler]
 >
 > options and explanations
 > ---------------------------
 >   help : Print this help message
 >
->   dpath : Path to download source of libraries (created if it does not exist).
+>   d dpath : Path to download source of libraries (created if it does not exist).
 >           Defaults to ${HOME}/Desktop/third_party/
 >
->   installpath : Path to install libraries (created if it does not exist).
+>   i installpath : Path to install libraries (created if it does not exist).
 >           Defaults to ${HOME}/Desktop/third_party_installed/
+>
+>   c compiler : C++ compiler to build/install libraries.
+>           If not provided, the best known option will be chosen.

--- a/detail/build_blaze.sh
+++ b/detail/build_blaze.sh
@@ -23,18 +23,20 @@ function elastica_detect_compiler() {
 	fi
 }
 elastica_detect_compiler
+_CXX_COMPILER=${2:-"${_CXX_}"}
 
 # >3.14
 # -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 cmake -B "${BLAZE_BUILD_DIR}" \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_CXX_COMPILER="${_CXX_}" \
+	-DCMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
 	-DBLAZE_SHARED_MEMORY_PARALLELIZATION=OFF \
 	-DUSE_LAPACK=OFF \
 	-S .
 cmake --build "${BLAZE_BUILD_DIR}"
 cmake --install "${BLAZE_BUILD_DIR}" --prefix "${BLAZE_INSTALL_PREFIX}"
 
+unset _CXX_COMPILER
 unset _CXX_
 unset -f elastica_detect_compiler
 unset BLAZE_BUILD_DIR

--- a/detail/build_blaze_tensor.sh
+++ b/detail/build_blaze_tensor.sh
@@ -25,16 +25,18 @@ function elastica_detect_compiler() {
 	fi
 }
 elastica_detect_compiler
+_CXX_COMPILER=${2:-"${_CXX_}"}
 
 # Requires >3.14
 cmake -B "${BLAZE_TENSOR_BUILD_DIR}" \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_CXX_COMPILER="${_CXX_}" \
+	-DCMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
 	-Dblaze_DIR="${BLAZE_PATH}" \
 	-S .
 cmake --build "${BLAZE_TENSOR_BUILD_DIR}"
 cmake --install "${BLAZE_TENSOR_BUILD_DIR}" --prefix "${BLAZE_TENSOR_INSTALL_PREFIX}"
 
+unset _CXX_COMPILER
 unset _CXX_
 unset -f elastica_detect_compiler
 unset BLAZE_PATH

--- a/detail/build_brigand.sh
+++ b/detail/build_brigand.sh
@@ -24,16 +24,18 @@ function elastica_detect_compiler() {
 	fi
 }
 elastica_detect_compiler
+_CXX_COMPILER=${2:-"${_CXX_}"}
 
 # Requires >3.14
 cmake -B "${BRIGAND_BUILD_DIR}" \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_CXX_COMPILER="${_CXX_}" \
+	-DCMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
 	-DBUILD_TESTING=OFF \
 	-S .
 cmake --build "${BRIGAND_BUILD_DIR}"
 cmake --install "${BRIGAND_BUILD_DIR}" --prefix "${BRIGAND_INSTALL_PREFIX}"
 
+unset _CXX_COMPILER
 unset _CXX_
 unset -f elastica_detect_compiler
 unset BRIGAND_BUILD_DIR

--- a/detail/build_cxxopts.sh
+++ b/detail/build_cxxopts.sh
@@ -24,17 +24,19 @@ function elastica_detect_compiler() {
 	fi
 }
 elastica_detect_compiler
+_CXX_COMPILER=${2:-"${_CXX_}"}
 
 # Requires >3.14
 cmake -B "${CXXOPTS_BUILD_DIR}" \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_CXX_COMPILER="${_CXX_}" \
+	-DCMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
 	-DCXXOPTS_BUILD_EXAMPLES=OFF \
 	-DCXXOPTS_BUILD_TESTS=OFF \
 	-S .
 cmake --build "${CXXOPTS_BUILD_DIR}"
 cmake --install "${CXXOPTS_BUILD_DIR}" --prefix "${CXXOPTS_INSTALL_PREFIX}"
 
+unset _CXX_COMPILER
 unset _CXX_
 unset -f elastica_detect_compiler
 unset CXXOPTS_BUILD_DIR

--- a/detail/build_yaml-cpp.sh
+++ b/detail/build_yaml-cpp.sh
@@ -23,17 +23,19 @@ function elastica_detect_compiler() {
 	fi
 }
 elastica_detect_compiler
+_CXX_COMPILER=${2:-"${_CXX_}"}
 
 # >3.14
 # -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 cmake -B "${YAML_CPP_BUILD_DIR}" \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_CXX_COMPILER="${_CXX_}" \
+	-DCMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
 	-DYAML_BUILD_SHARED_LIBS=on \
 	-S .
 cmake --build "${YAML_CPP_BUILD_DIR}"
 cmake --install "${YAML_CPP_BUILD_DIR}" --prefix "${YAML_CPP_INSTALL_PREFIX}"
 
+unset _CXX_COMPILER
 unset _CXX_
 unset -f elastica_detect_compiler
 unset YAML_CPP_BUILD_DIR


### PR DESCRIPTION
Fixes #5 

## Features
- Adds keyword arguments for all options
- Adds the `c|-compiler|--compiler` to choose the C++ compiler
- Updated help message and README.
```
usage
-----
./install.sh [-d dpath] [-i ipath] [-c compiler]

options and explanations
---------------------------
  help : Print this help message

  d dpath : Path to download source of libraries (created if it does not exist).
          Defaults to /root/Desktop/third_party/

  i installpath : Path to install libraries (created if it does not exist).
          Defaults to /root/Desktop/third_party_installed/

  c compiler : C++ compiler to build/install libraries.
          If not provided, the best known option will be chosen.
```