### PR TITLE
feat : HDF5/HighFive support

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -64,3 +64,30 @@ jobs:
       - name: Check installation
         run: "bash ${GITHUB_WORKSPACE}/install.sh -d ${HOME}/code/dpath -i ${HOME}/code/ipath -c g++"
         shell: bash
+
+build_h5:
+    name: Build with hdf5 support
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Setup GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 9
+          platform: x64
+
+      - name: Install HDF5
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends libhdf5-dev
+
+      - name: Check installation
+        run: "bash ${GITHUB_WORKSPACE}/install.sh"
+        shell: bash

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -65,29 +65,29 @@ jobs:
         run: "bash ${GITHUB_WORKSPACE}/install.sh -d ${HOME}/code/dpath -i ${HOME}/code/ipath -c g++"
         shell: bash
 
-build_h5:
-    name: Build with hdf5 support
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+  build_h5:
+      name: Build with hdf5 support
+      # The type of runner that the job will run on
+      runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      # Steps represent a sequence of tasks that will be executed as part of the job
+      steps:
+        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 1
 
-      - name: Setup GCC
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: 9
-          platform: x64
+        - name: Setup GCC
+          uses: egor-tensin/setup-gcc@v1
+          with:
+            version: 9
+            platform: x64
 
-      - name: Install HDF5
-        run: |
-          sudo apt update
-          sudo apt install --no-install-recommends libhdf5-dev
+        - name: Install HDF5
+          run: |
+            sudo apt update
+            sudo apt install --no-install-recommends libhdf5-dev
 
-      - name: Check installation
-        run: "bash ${GITHUB_WORKSPACE}/install.sh"
-        shell: bash
+        - name: Check installation
+          run: "bash ${GITHUB_WORKSPACE}/install.sh"
+          shell: bash

--- a/detail/build_HighFive.sh
+++ b/detail/build_HighFive.sh
@@ -38,6 +38,7 @@ if command -v h5cc >/dev/null 2>&1; then # h5cc exists, so good chance that Cmak
 		-D HIGHFIVE_USE_OPENCV=OFF \
 		-D HIGHFIVE_USE_XTENSOR=OFF \
 		-D HIGHFIVE_EXAMPLES=OFF \
+		-D HIGHFIVE_UNIT_TESTS=OFF \
 		-D HIGHFIVE_PARALLEL_HDF5=OFF \
 		-D HIGHFIVE_BUILD_DOCS=OFF \
 		-S .

--- a/detail/build_HighFive.sh
+++ b/detail/build_HighFive.sh
@@ -26,23 +26,27 @@ function elastica_detect_compiler() {
 elastica_detect_compiler
 _CXX_COMPILER=${2:-"${_CXX_}"}
 
-# Requires >3.14
-cmake -B "${HIGHFIVE_BUILD_DIR}" \
-	-D CMAKE_BUILD_TYPE=Release \
-	-D CMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
-	-D HIGHFIVE_USE_BOOST=OFF \
-	-D HIGHFIVE_USE_HALF_FLOAT=OFF \
-	-D HIGHFIVE_USE_EIGEN=OFF \
-	-D HIGHFIVE_USE_OPENCV=OFF \
-	-D HIGHFIVE_USE_XTENSOR=OFF \
-	-D HIGHFIVE_EXAMPLES=OFF \
-	-D HIGHFIVE_PARALLEL_HDF5=OFF \
-	-D HIGHFIVE_BUILD_DOCS=OFF \
-	-S .
-# doesn't need to be parallel as its header only
-cmake --build "${HIGHFIVE_BUILD_DIR}"
-cmake --install "${HIGHFIVE_BUILD_DIR}" --prefix "${HIGHFIVE_INSTALL_PREFIX}"
-
+# We need high-five to be found, else this steps error out. Rather than searching for the libraries which is harder,
+# we search for the compiler-wrapper here.
+if command -v h5cc >/dev/null 2>&1; then # h5cc exists, so good chance that Cmake wont bug out
+	cmake -B "${HIGHFIVE_BUILD_DIR}" \
+		-D CMAKE_BUILD_TYPE=Release \
+		-D CMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
+		-D HIGHFIVE_USE_BOOST=OFF \
+		-D HIGHFIVE_USE_HALF_FLOAT=OFF \
+		-D HIGHFIVE_USE_EIGEN=OFF \
+		-D HIGHFIVE_USE_OPENCV=OFF \
+		-D HIGHFIVE_USE_XTENSOR=OFF \
+		-D HIGHFIVE_EXAMPLES=OFF \
+		-D HIGHFIVE_PARALLEL_HDF5=OFF \
+		-D HIGHFIVE_BUILD_DOCS=OFF \
+		-S .
+	# doesn't need to be parallel as its header only
+	cmake --build "${HIGHFIVE_BUILD_DIR}"
+	cmake --install "${HIGHFIVE_BUILD_DIR}" --prefix "${HIGHFIVE_INSTALL_PREFIX}"
+else
+	echo "h5cc was not found. Chances are that HDF5 is not installed on your system, so the HighFive dependency will not be installed."
+fi
 unset _CXX_COMPILER
 unset _CXX_
 unset -f elastica_detect_compiler

--- a/detail/build_HighFive.sh
+++ b/detail/build_HighFive.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+
+# HIGHFIVE automatically installs in the HIGHFIVE subdirectory
+HIGHFIVE_BUILD_DIR="build"
+HIGHFIVE_INSTALL_PREFIX=${1:-"${HOME}/Desktop/third_party_installed"}
+
+mkdir -p "${HIGHFIVE_INSTALL_PREFIX}"
+
+function elastica_detect_compiler() {
+	# check gcc version starting from 9 on to 4
+	local version_array=($(seq 11 -1 4))
+	local CXX_ver_arr=("${version_array[@]/#/g++-}")
+	local CC_ver_arr=("${version_array[@]/#/g++-}")
+	# Try and detect GNU g++ from the shell, if not use default CC
+	for cxx_ver in "${CXX_ver_arr[@]}"; do
+		if command -v "${cxx_ver}" >/dev/null 2>&1 && "${cxx_ver}" --version | grep -q '[Gg][Cc][Cc]'; then
+			_CXX_="${cxx_ver}"
+			break
+		fi
+	done
+	# Check if not set, else set it
+	if [ -z "${_CXX_}" ] && g++ --version; then
+		_CXX_="g++"
+	fi
+}
+elastica_detect_compiler
+_CXX_COMPILER=${2:-"${_CXX_}"}
+
+# Requires >3.14
+cmake -B "${HIGHFIVE_BUILD_DIR}" \
+	-D CMAKE_BUILD_TYPE=Release \
+	-D CMAKE_CXX_COMPILER="${_CXX_COMPILER}" \
+	-D HIGHFIVE_USE_BOOST=OFF \
+	-D HIGHFIVE_USE_HALF_FLOAT=OFF \
+	-D HIGHFIVE_USE_EIGEN=OFF \
+	-D HIGHFIVE_USE_OPENCV=OFF \
+	-D HIGHFIVE_USE_XTENSOR=OFF \
+	-D HIGHFIVE_EXAMPLES=OFF \
+	-D HIGHFIVE_PARALLEL_HDF5=OFF \
+	-D HIGHFIVE_BUILD_DOCS=OFF \
+	-S .
+# doesn't need to be parallel as its header only
+cmake --build "${HIGHFIVE_BUILD_DIR}"
+cmake --install "${HIGHFIVE_BUILD_DIR}" --prefix "${HIGHFIVE_INSTALL_PREFIX}"
+
+unset _CXX_COMPILER
+unset _CXX_
+unset -f elastica_detect_compiler
+unset HIGHFIVE_BUILD_DIR
+unset HIGHFIVE_INSTALL_PREFIX

--- a/install.sh
+++ b/install.sh
@@ -15,17 +15,17 @@ read -rd '' globalhelp <<-EOF
 	usage
 	-----
 	./install.sh [-d dpath] [-i ipath] [-c compiler]
-
+	
 	options and explanations
 	---------------------------
 	  help : Print this help message
-
+	
 	  d dpath : Path to download source of libraries (created if it does not exist).
 	          Defaults to ${HOME}/Desktop/third_party/
-
+	
 	  i installpath : Path to install libraries (created if it does not exist).
 	          Defaults to ${HOME}/Desktop/third_party_installed/
-
+	
 	  c compiler : C++ compiler to build/install libraries.
 	          If not provided, the best known option will be chosen.
 EOF
@@ -111,6 +111,7 @@ setup_library "blaze_tensor" "https://github.com/STEllAR-GROUP/blaze_tensor.git"
 setup_library "brigand" "https://github.com/edouarda/brigand.git"
 setup_library "cxxopts" "https://github.com/jarro2783/cxxopts.git"
 setup_library "yaml-cpp" "https://github.com/jbeder/yaml-cpp.git"
+setup_library "HighFive" "https://github.com/BlueBrain/HighFive"
 
 touch ~/.localrc
 chmod u+rwx ~/.localrc
@@ -130,6 +131,10 @@ fi
 # This will add to previously installed quicksetup profiles as well
 if [ ! -v YamlCpp_ROOT ]; then
 	echo "export YamlCpp_ROOT='${INSTALL_PATH}'" >>~/.localrc
+fi
+# We have a FindHighFive.cmake that is case-insensitive
+if [ ! -v HighFive_ROOT ]; then
+	echo "export HighFive_ROOT='${INSTALL_PATH}'" >>~/.localrc
 fi
 
 read -rd '' finalmessage <<-EOF


### PR DESCRIPTION
Adds support for installing HighFive.

HDF5 is a pre-requisite. If its not pre-installed, a message is thrown and HighFive is not installed. Else, installation proceeds like normal.